### PR TITLE
chore: migrate renovate preset to corrupt952/renovate-config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["github>corrupt952/.github:default.json5"],
+  extends: ["github>corrupt952/renovate-config:default.json5"],
 
   customManagers: [
     {


### PR DESCRIPTION
## Background

Consolidating Renovate-related configuration to a dedicated repo. The shared preset previously hosted at `corrupt952/.github:default.json5` has been moved to `corrupt952/renovate-config:default.json5`.

This PR updates the preset reference. Functionality is unchanged.

## Related

- `corrupt952/renovate-config` — new home of the shared preset
- `corrupt952/.github` — old location (will be removed once all repos are migrated)